### PR TITLE
fix: arch from config bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Arch `from_config` bug for literal params.
+
 ### Security
 
 ### Dependencies

--- a/modulus/sym/models/arch.py
+++ b/modulus/sym/models/arch.py
@@ -18,9 +18,9 @@ from torch import Tensor
 import numpy as np
 import logging
 import functorch
+import asl
 
 from termcolor import colored
-from ast import literal_eval
 from inspect import signature, _empty
 from typing import Optional, Callable, List, Dict, Union, Tuple
 from modulus.sym.constants import NO_OP_SCALE
@@ -522,7 +522,7 @@ class Arch(nn.Module):
                 ):
                     try:
                         # Attempt literal conversion from string
-                        param_literal = literal_eval(cfg[parameter.name])
+                        param_literal = eval(cfg[parameter.name])
                     except:
                         try:
                             # Try eval for python code that needs to run

--- a/modulus/sym/models/arch.py
+++ b/modulus/sym/models/arch.py
@@ -18,7 +18,7 @@ from torch import Tensor
 import numpy as np
 import logging
 import functorch
-import asl
+import ast
 
 from termcolor import colored
 from inspect import signature, _empty


### PR DESCRIPTION
# Modulus Pull Request

## Description
Fixing a bug in model arch from config. 
Bug prevents models with literal evals from being instantiated

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus-sym/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/modulus-sym/blob/main/CHANGELOG.md) is
up to date with these changes.

## Dependencies

None