### PR TITLE
Update numpy bool scalar type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Arch `from_config` bug for literal params.
+- Update `np.bool` to `np.bool_`
 
 ### Security
 

--- a/modulus/sym/domain/inferencer/vtkpointwise.py
+++ b/modulus/sym/domain/inferencer/vtkpointwise.py
@@ -95,7 +95,7 @@ class PointVTKInferencer(PointwiseInferencer):
             if len(args) == 0:
                 args = list(invar.keys())  # Hope your inputs all go into the mask
             mask_input = {key: invar[key] for key in args if key in invar}
-            mask = np.squeeze(mask_fn(**mask_input).astype(np.bool))
+            mask = np.squeeze(mask_fn(**mask_input).astype(np.bool_))
             # True points get masked while False get kept, flip for index
             self.mask_index = np.logical_not(mask)
             # Mask out to only masked points (only inference here)


### PR DESCRIPTION
# Modulus Pull Request

## Description
Fixes the deprecated `np.bool`

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus-sym/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/modulus-sym/blob/main/CHANGELOG.md) is
up to date with these changes.

## Dependencies

<!-- Call out any new dependencies needed if any -->