### PR TITLE
Hot fix NCCL CUDA Graphs bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Arch `from_config` bug for literal params.
 - Fixed fused SiLU activation test.
 - Update `np.bool` to `np.bool_`.
+- Added a workaround fix for the CUDA graphs error in multi-node runs
 
 ### Security
 

--- a/modulus/sym/trainer.py
+++ b/modulus/sym/trainer.py
@@ -737,7 +737,10 @@ class Trainer(AdamMixin, AdaHessianMixin, BFGSMixin):
 
             self.g = torch.cuda.CUDAGraph()
             self.global_optimizer_model.zero_grad(set_to_none=True)
-            time.sleep(30)
+            # TODO: temporary workaround till this issue is fixed:
+            # https://github.com/pytorch/pytorch/pull/104487#issuecomment-1638665876
+            delay = os.environ.get("MODULUS_CUDA_GRAPH_CAPTURE_DELAY", "30")
+            time.sleep(int(delay))
             with torch.cuda.graph(self.g):
                 # compute gradients
                 self.loss_static, self.losses_static = self.compute_gradients(

--- a/modulus/sym/trainer.py
+++ b/modulus/sym/trainer.py
@@ -737,6 +737,7 @@ class Trainer(AdamMixin, AdaHessianMixin, BFGSMixin):
 
             self.g = torch.cuda.CUDAGraph()
             self.global_optimizer_model.zero_grad(set_to_none=True)
+            time.sleep(30)
             with torch.cuda.graph(self.g):
                 # compute gradients
                 self.loss_static, self.losses_static = self.compute_gradients(

--- a/modulus/sym/trainer.py
+++ b/modulus/sym/trainer.py
@@ -739,7 +739,7 @@ class Trainer(AdamMixin, AdaHessianMixin, BFGSMixin):
             self.global_optimizer_model.zero_grad(set_to_none=True)
             # TODO: temporary workaround till this issue is fixed:
             # https://github.com/pytorch/pytorch/pull/104487#issuecomment-1638665876
-            delay = os.environ.get("MODULUS_CUDA_GRAPH_CAPTURE_DELAY", "30")
+            delay = os.environ.get("MODULUS_CUDA_GRAPH_CAPTURE_DELAY", "10")
             time.sleep(int(delay))
             with torch.cuda.graph(self.g):
                 # compute gradients


### PR DESCRIPTION
# Modulus Pull Request

## Description
Closes #47 

The workaround fix adds a time delay between the warmup steps and the start of the graph capture to allow enough time for NCCL watchdog to clean-up work. The fix was stress tested against FPGA example, and it passed 20/20 times.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus-sym/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/modulus-sym/blob/main/CHANGELOG.md) is
up to date with these changes.

## Dependencies

<!-- Call out any new dependencies needed if any -->