### PR TITLE
Add benchmarking configs to FPGA

### DIFF
--- a/examples/fpga/laminar/conf/config.yaml
+++ b/examples/fpga/laminar/conf/config.yaml
@@ -55,6 +55,13 @@ custom:
   exact_continuity: false
   quasirandom: false
   adaptive_activations: false
+  num_workers:
+    inlet: 0
+    outlet: 0
+    no_slip: 0
+    lr_interior: 0
+    hr_interior: 0
+    integral_continuity: 0
 
 network_dir: "network_checkpoint_flow"
 initialization_network_dir: ""

--- a/examples/fpga/laminar/conf/mode/benchmarking.yaml
+++ b/examples/fpga/laminar/conf/mode/benchmarking.yaml
@@ -1,0 +1,36 @@
+# @package _global_
+training:
+  rec_validation_freq: 100000
+  rec_inference_freq: 100000
+  rec_monitor_freq: 100000
+  rec_constraint_freq: 100000
+  max_steps: 3000
+  grad_agg_freq: 1
+  rec_results_freq: 100000
+  save_network_freq: 100000
+  print_stats_freq: 1000
+  summary_freq: 100000
+  amp: False
+  amp_dtype: "float16"
+
+custom:
+  arch: "FullyConnectedArch"
+  exact_continuity: false
+  quasirandom: false
+  adaptive_activations: false
+  num_workers:
+    inlet: 1
+    outlet: 1
+    no_slip: 1
+    lr_interior: 1
+    hr_interior: 1
+    integral_continuity: 1  
+
+batch_size:
+  inlet: 4096
+  outlet: 4096
+  no_slip: 192000
+  lr_interior: 20480
+  hr_interior: 20480
+  integral_continuity: 102400
+  num_integral_continuity: 8

--- a/examples/fpga/laminar/conf/mode/benchmarking.yaml
+++ b/examples/fpga/laminar/conf/mode/benchmarking.yaml
@@ -1,3 +1,17 @@
+# Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # @package _global_
 training:
   rec_validation_freq: 100000

--- a/examples/fpga/laminar/fpga_flow.py
+++ b/examples/fpga/laminar/fpga_flow.py
@@ -49,6 +49,7 @@ from fpga_geometry import *
 
 @modulus.sym.main(config_path="conf", config_name="config")
 def run(cfg: ModulusConfig) -> None:
+    print(cfg)
     # params for simulation
     # fluid params
     nu = 0.02
@@ -125,6 +126,7 @@ def run(cfg: ModulusConfig) -> None:
         criteria=Eq(x, channel_origin[0]),
         lambda_weighting={"u": channel_sdf, "v": 1.0, "w": 1.0},  # weight zero on edges
         quasirandom=cfg.custom.quasirandom,
+        num_workers=cfg.custom.num_workers.inlet,
     )
     flow_domain.add_constraint(constraint_inlet, "inlet")
 
@@ -136,6 +138,7 @@ def run(cfg: ModulusConfig) -> None:
         batch_size=cfg.batch_size.outlet,
         criteria=Eq(x, channel_origin[0] + channel_dim[0]),
         quasirandom=cfg.custom.quasirandom,
+        num_workers=cfg.custom.num_workers.outlet,
     )
     flow_domain.add_constraint(constraint_outlet, "outlet")
 
@@ -146,6 +149,7 @@ def run(cfg: ModulusConfig) -> None:
         outvar={"u": 0, "v": 0, "w": 0},
         batch_size=cfg.batch_size.no_slip,
         quasirandom=cfg.custom.quasirandom,
+        num_workers=cfg.custom.num_workers.no_slip,
     )
     flow_domain.add_constraint(no_slip, "no_slip")
 
@@ -163,6 +167,7 @@ def run(cfg: ModulusConfig) -> None:
             "momentum_z": Symbol("sdf"),
         },
         quasirandom=cfg.custom.quasirandom,
+        num_workers=cfg.custom.num_workers.lr_interior,
     )
     flow_domain.add_constraint(lr_interior, "lr_interior")
 
@@ -182,6 +187,7 @@ def run(cfg: ModulusConfig) -> None:
             "momentum_z": Symbol("sdf"),
         },
         quasirandom=cfg.custom.quasirandom,
+        num_workers=cfg.custom.num_workers.hr_interior,
     )
     flow_domain.add_constraint(hr_interior, "hr_interior")
 
@@ -199,6 +205,7 @@ def run(cfg: ModulusConfig) -> None:
         criteria=integral_criteria,
         lambda_weighting={"normal_dot_vel": 1.0},
         quasirandom=cfg.custom.quasirandom,
+        num_workers=cfg.custom.num_workers.integral_continuity,
     )
     flow_domain.add_constraint(integral_continuity, "integral_continuity")
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
Adds benchmarking configuration to the FPGA example. To run in benchmarking mode, run using:

```
python fpga_flow.py +mode=benchmarking
```
## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus-sym/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/modulus-sym/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/modulus-sym/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->