### PR TITLE
Heaviside hotfix

### DIFF
--- a/modulus/sym/utils/sympy/numpy_printer.py
+++ b/modulus/sym/utils/sympy/numpy_printer.py
@@ -181,7 +181,9 @@ def _max_np(x, axis=None):
     return return_value
 
 
-def _heaviside_np(x, x2=0.5):
+def _heaviside_np(x, x2=0):
+    # force x2 to 0
+    x2 = 0
     return np.heaviside(x, x2)
 
 

--- a/modulus/sym/utils/sympy/torch_printer.py
+++ b/modulus/sym/utils/sympy/torch_printer.py
@@ -72,9 +72,8 @@ def _where_torch(conditions, x, y):
     return torch.where(conditions, x, y)
 
 
-def _heaviside_torch(x, values=0.5):
-    values = torch.tensor([values]).to(x.device)
-    return torch.heaviside(x, values)
+def _heaviside_torch(x, values=0):
+    return torch.maximum(torch.sign(x), torch.zeros(1, device=x.device))
 
 
 def _sqrt_torch(x):


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
A change was added to the Heaviside function in torch printer in this PR: https://github.com/NVIDIA/modulus-sym/pull/83/files

While this works for the forward function, the derivative of heaviside is not defined (this is needed for our zero equation turbulence examples) - the bug was pointed out during the QA runs (ref: [NVBug](https://nvbugswb.nvidia.com/NvBugs5/SWBug.aspx?bugid=4380858&cmtNo=), [PyT Forums](https://discuss.pytorch.org/t/runtimeerror-derivative-for-aten-heaviside-is-not-implemented/164707)). This PR reverts the change to the heaviside function and also forces the value to be 0 for the numpy implementation. This was tested by running the pytests and the unittests both. 

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus-sym/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/modulus-sym/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/modulus-sym/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->