### PR TITLE
Add git hash to the docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ FROM $BASE_CONTAINER as builder
 ARG TARGETPLATFORM
 
 # Update pip and setuptools
-RUN pip install --upgrade pip setuptools  
+RUN pip install "pip==23.2.1" "setuptools==68.2.2"  
 
 # Setup git lfs, graphviz gl1(vtk dep)
 RUN apt-get update && \
@@ -29,22 +29,22 @@ RUN apt-get update && \
 COPY . /modulus-sym/
 RUN if [ "$TARGETPLATFORM" = "linux/arm64" ] && [ -e "/modulus-sym/deps/vtk-9.2.6.dev0-cp310-cp310-linux_aarch64.whl" ]; then \
 	echo "VTK wheel for $TARGETPLATFORM exists, installing!" && \
-	pip install /modulus-sym/deps/vtk-9.2.6.dev0-cp310-cp310-linux_aarch64.whl; \
+	pip install --no-cache-dir /modulus-sym/deps/vtk-9.2.6.dev0-cp310-cp310-linux_aarch64.whl; \
     elif [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
 	echo "Installing vtk for: $TARGETPLATFORM" && \
-	pip install "vtk>=9.2.6"; \ 
+	pip install --no-cache-dir "vtk>=9.2.6"; \ 
     else \
 	echo "Installing vtk for: $TARGETPLATFORM from source" && \
 	apt-get update && apt-get install -y libgl1-mesa-dev && \
 	git clone https://gitlab.kitware.com/vtk/vtk.git && cd vtk && git checkout tags/v9.2.6 && git submodule update --init --recursive && \
 	mkdir build && cd build && cmake -GNinja -DVTK_WHEEL_BUILD=ON -DVTK_WRAP_PYTHON=ON /workspace/vtk/ && ninja && \
 	python setup.py bdist_wheel && \
-	pip install dist/vtk-9.2.6.dev0-cp310-cp310-linux_aarch64.whl && \
+	pip install --no-cache-dir dist/vtk-9.2.6.dev0-cp310-cp310-linux_aarch64.whl && \
 	cd ../../ && rm -r vtk; \
     fi
 
 # Install modulus sym dependencies
-RUN pip install "hydra-core>=1.2.0" "termcolor>=2.1.1" "chaospy>=4.3.7" "Cython==0.29.28" "numpy-stl==2.16.3" "opencv-python==4.5.5.64" \
+RUN pip install --no-cache-dir "hydra-core>=1.2.0" "termcolor>=2.1.1" "chaospy>=4.3.7" "Cython==0.29.28" "numpy-stl==2.16.3" "opencv-python==4.5.5.64" \
     "scikit-learn==1.0.2" "symengine>=0.10.0" "sympy==1.12" "timm==0.5.4" "torch-optimizer==0.3.0" "transforms3d==0.3.1" \
     "typing==3.7.4.3" "pillow==10.0.1" "notebook==6.4.12" "mistune==2.0.3" "pint==0.19.2" "tensorboard>=2.8.0"
 
@@ -52,13 +52,13 @@ RUN pip install "hydra-core>=1.2.0" "termcolor>=2.1.1" "chaospy>=4.3.7" "Cython=
 ENV TCNN_CUDA_ARCHITECTURES="60;70;75;80;86;90"
 RUN if [ "$TARGETPLATFORM" = "linux/amd64" ] && [ -e "/modulus-sym/deps/tinycudann-1.7-cp310-cp310-linux_x86_64.whl" ]; then \
         echo "Tiny CUDA NN wheel for $TARGETPLATFORM exists, installing!" && \
-        pip install --force-reinstall /modulus-sym/deps/tinycudann-1.7-cp310-cp310-linux_x86_64.whl; \
+        pip install --force-reinstall --no-cache-dir /modulus-sym/deps/tinycudann-1.7-cp310-cp310-linux_x86_64.whl; \
     elif [ "$TARGETPLATFORM" = "linux/arm64" ] && [ -e "/modulus-sym/deps/tinycudann-1.7-cp310-cp310-linux_aarch64.whl" ]; then \
         echo "Tiny CUDA NN wheel for $TARGETPLATFORM exists, installing!" && \
-        pip install --force-reinstall /modulus-sym/deps/tinycudann-1.7-cp310-cp310-linux_aarch64.whl; \
+        pip install --force-reinstall --no-cache-dir /modulus-sym/deps/tinycudann-1.7-cp310-cp310-linux_aarch64.whl; \
     else \
         echo "No Tiny CUDA NN wheel present, building from source" && \
-	pip install git+https://github.com/NVlabs/tiny-cuda-nn/@master#subdirectory=bindings/torch; \	
+	pip install --no-cache-dir git+https://github.com/NVlabs/tiny-cuda-nn/@master#subdirectory=bindings/torch; \	
     fi
 
 
@@ -108,9 +108,9 @@ ENV LD_LIBRARY_PATH="/external/lib:${LD_LIBRARY_PATH}" \
 FROM pysdf-install as ci
 
 # Install Modulus
-RUN pip install --upgrade git+https://github.com/NVIDIA/modulus.git
+RUN pip install --upgrade --no-cache-dir git+https://github.com/NVIDIA/modulus.git
 
-RUN pip install "black==22.10.0" "interrogate==1.5.0" "coverage==6.5.0"
+RUN pip install --no-cache-dir "black==22.10.0" "interrogate==1.5.0" "coverage==6.5.0"
 COPY . /modulus-sym/
 RUN cd /modulus-sym/ && pip install -e . --no-deps && rm -rf /modulus-sym/
 
@@ -119,7 +119,7 @@ FROM builder as no-pysdf
 
 # Install modulus sym
 COPY . /modulus-sym/
-RUN cd /modulus-sym/ && pip install . --no-deps
+RUN cd /modulus-sym/ && pip install --no-cache-dir . --no-deps
 RUN rm -rf /modulus-sym/
 
 # Image with pysdf 
@@ -128,11 +128,15 @@ FROM pysdf-install as deploy
 
 # Install modulus sym
 COPY . /modulus-sym/
-RUN cd /modulus-sym/ && pip install . --no-deps
+RUN cd /modulus-sym/ && pip install --no-cache-dir . --no-deps
 RUN rm -rf /modulus-sym/
+
+# Set Git Hash as a environment variable
+ARG MODULUS_SYM_GIT_HASH
+ENV MODULUS_SYM_GIT_HASH=${MODULUS_SYM_GIT_HASH:-unknown}
 
 # Docs image
 FROM deploy as docs
 # Install packages for Sphinx build
-RUN pip install "recommonmark==0.7.1" "sphinx==5.1.1" "sphinx-rtd-theme==1.0.0" "pydocstyle==6.1.1" "nbsphinx==0.8.9" "nbconvert==6.4.3" "jinja2==3.0.3"
+RUN pip install --no-cache-dir "recommonmark==0.7.1" "sphinx==5.1.1" "sphinx-rtd-theme==1.0.0" "pydocstyle==6.1.1" "nbsphinx==0.8.9" "nbconvert==6.4.3" "jinja2==3.0.3"
 RUN wget https://github.com/jgm/pandoc/releases/download/3.1.2/pandoc-3.1.2-linux-amd64.tar.gz && tar xvzf pandoc-3.1.2-linux-amd64.tar.gz --strip-components 1 -C /usr/local/ 

--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,10 @@ else
     $(error Unknown CPU architecture ${ARCH} detected)
 endif
 
+MODULUS_SYM_GIT_HASH = $(shell git rev-parse --short HEAD)
+
 container-deploy:
-	docker build -t modulus-sym:deploy --build-arg TARGETPLATFORM=${TARGETPLATFORM} --target deploy -f Dockerfile .
+	docker build -t modulus-sym:deploy --build-arg TARGETPLATFORM=${TARGETPLATFORM} --build-arg MODULUS_SYM_GIT_HASH=${MODULUS_SYM_GIT_HASH} --target deploy -f Dockerfile .
 
 container-ci:
 	docker build -t modulus-sym:ci --build-arg TARGETPLATFORM=${TARGETPLATFORM} --target ci -f Dockerfile .


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
Adds git hash to the docker container. If the build arg is not provided, it will default to unknown.

Also adds `--no-cache-dir` option to all pip commands. 

Similar to https://github.com/NVIDIA/modulus/pull/256, https://github.com/NVIDIA/modulus/pull/255

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus-sym/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/modulus-sym/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/modulus-sym/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->