### PR TITLE
Fix conv fc model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix bug for `ConvFullyConnectedArch`.
+
 ### Security
 
 ### Dependencies

--- a/modulus/sym/models/fully_connected.py
+++ b/modulus/sym/models/fully_connected.py
@@ -66,11 +66,13 @@ class FullyConnectedArchCore(nn.Module):
         for i in range(nr_layers):
             self.layers.append(
                 fc_layer(
-                    layer_in_features,
-                    layer_size,
-                    get_activation_fn(activation_fn[i], out_features=out_features),
-                    weight_norm,
-                    activation_par,
+                    in_features=layer_in_features,
+                    out_features=layer_size,
+                    activation_fn=get_activation_fn(
+                        activation_fn[i], out_features=out_features
+                    ),
+                    weight_norm=weight_norm,
+                    activation_par=activation_par,
                 )
             )
             layer_in_features = layer_size


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
The order of args for `Conv1dFCLayer` layer changed during Sym-Core integration PR here: https://github.com/NVIDIA/modulus-sym/pull/62. This caused the values for `weight_norm` and `activation_par` to be inverted for `Conv1dFCLayer`. This PR fixes that issue by making the args explicit. 

This also fixes the FNO predictions as `ConvFullyConnectedArch` model was used for decoder. 

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus-sym/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/modulus-sym/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/modulus-sym/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->