### PR TITLE
Updating FusedSiLU activation test to conform with updated nvFuser kernel generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix bug for `ConvFullyConnectedArch`.
+- Updating `Activation.SILU` test to conform with updated nvFuser kernel generation.
 
 ### Security
 

--- a/test/test_models/test_activation.py
+++ b/test/test_models/test_activation.py
@@ -143,7 +143,7 @@ def test_activation_fused_silu():
     print("silu_scripted_3rd num_events: ", num_kernels)
     if version.parse(torch.__version__) >= version.parse("1.12.9"):
         # fwd + 1st_deriv + 2nd_deriv + 3rd_deriv kernels
-        assert num_kernels <= 6
+        assert num_kernels <= 7
     else:
         warnings.warn(f"Fused SiLU is not supported for torch {torch.__version__}")
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

With the latest nvFuser update, one additional kernel is generated in the SiLU triple backward pass implementation. This is still much fewer than the ~35 kernels that torch generates by default, so is not a big concern. Updating the test to conform with this latest nvFuser version.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus-sym/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/modulus-sym/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/modulus-sym/issues) is linked to this pull request.

## Dependencies
<!-- Call out any new dependencies needed if any -->

None