### PR TITLE
Update sckit-learn dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "Cython==0.29.28",
     "numpy-stl==2.16.3",
     "opencv-python==4.5.5.64",
-    "scikit-learn==1.0.2",
+    "scikit-learn>=1.0.2",
     "symengine>=0.10.0",
     "sympy==1.12",
     "timm==0.5.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "Cython==0.29.28",
     "numpy-stl==2.16.3",
     "opencv-python==4.5.5.64",
-    "scikit-learn>=1.0.2",
+    "scikit-learn>=1.2.0",
     "symengine>=0.10.0",
     "sympy==1.12",
     "timm==0.5.4",


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

Fixes CVE found by internal scans

```
-> Vulnerability found in scikit-learn version 1.0.2
   Vulnerability ID: 54297
   Affected spec: <1.1.0rc1
   ADVISORY: Scikit-learn 1.1.0rc1 includes a fix for CVE-2020-28975:
   svm_predict_values in svm.cpp in Libsvm v324, as used in scikit-learn and
   other products, allows attackers to cause a denial of service
   (segmentation fault) via a crafted model SVM (introduced via pickle, json,
   or any other model permanence standard) with a large value in the
   _n_support array. NOTE: the scikit-learn vendor's position is that the
   behavior can only occur if the library's API is violated by an application
   that changes a private attribute.https://github.com/scikit-learn/scikit-
   learn/commit/1bf13d567d3cd74854aa8343fd25b61dd768bb85
   CVE-2020-28975
   For more information about this vulnerability, visit
   https://data.safetycli.com/v/54297/97c
   To ignore this vulnerability, use PyUp vulnerability id 54297 in safety’s
   ignore command-line argument or add the ignore to your safety policy file.
```

## Description


## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus-sym/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/modulus-sym/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/modulus-sym/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->