### PR TITLE
Fix typo in examples Readme

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -46,7 +46,7 @@ such models can help solve real world problems.
 |[FPGA Heatsink](./fpga/)| Multiple Models (including Fourier Feature MLP PINN, SIRENS, etc.) |Advanced|Steady state, Multi-Node|
 |[Limerock Industrial Heatsink](./limerock/)| Fourier Feature MLP PINN |Advanced|Steady state, Multi-Node|
 
-## Geophyscis
+## Geophysics
 
 |Use case|Model|Level|Attributes|
 | --- | --- | --- | --- |


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Docs-only change to fix a typo found upon browsing the examples folder.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus-sym/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/modulus-sym/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/modulus-sym/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->
None