### PR TITLE
Updating the backed for SDF calculation in STL module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,12 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Dependencies
 
-
 ## [1.6.0] - 2024-07-XX
 
 ### Added
 
 ### Changed
+
+- Warp based backed for STL geometry handling
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -67,36 +67,11 @@ pip install .
 
 ### Source Container
 
-To build release image, you will need to do the below preliminary steps:
-
-Clone this repo, and download the Optix SDK from
-<https://developer.nvidia.com/designworks/optix/downloads/legacy>.
-
-```bash
-git clone https://github.com/NVIDIA/modulus-sym.git
-cd modulus-sym/ && mkdir deps
-```
-
-Currently Modulus supports v7.0. Place the Optix file in the deps directory and make it
-executable. Also clone the pysdf library in the deps folder (NVIDIA Internal)
-
-```bash
-chmod +x deps/NVIDIA-OptiX-SDK-7.0.0-linux64.sh 
-git clone <internal pysdf repo>
-```
-
-Then to build the image, insert next tag and run below:
+To build release image insert next tag and run below:
 
 ```bash
 docker build -t modulus-sym:deploy \
     --build-arg TARGETPLATFORM=linux/amd64 --target deploy -f Dockerfile .
-```
-
-Alternatively, if you want to skip pysdf installation, you can run the following:
-
-```bash
-docker build -t modulus-sym:deploy \
-    --build-arg TARGETPLATFORM=linux/amd64 --target no-pysdf -f Dockerfile .
 ```
 
 Currently only `linux/amd64` and `linux/arm64` platforms are supported.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,7 +45,7 @@ exclude_patterns = [
 ]
 
 # Fake imports
-autodoc_mock_imports = ["pysdf", "quadpy", "functorch"]
+autodoc_mock_imports = ["quadpy", "functorch"]
 
 extensions = [
     "recommonmark",


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
Post this PR: https://github.com/NVIDIA/modulus/pull/389, we can switch to warp based backend for the STL SDF calculation inside Modulus. This also makes this utility more accessible to users not using Modulus docker container. Changes to Dockerfile have also been completed.  

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus-sym/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/modulus-sym/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/modulus-sym/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->