### PR TITLE
Add Automatic Mixed Precision (AMP) support for derivatives.

### DIFF
--- a/.github/workflows/blossom-ci.yml
+++ b/.github/workflows/blossom-ci.yml
@@ -47,7 +47,8 @@ jobs:
            github.actor == 'akshaysubr' ||
            github.actor == 'loliverhennigh' ||
            github.actor == 'mnabian' ||
-           github.actor == 'crackcode123'
+           github.actor == 'crackcode123' ||
+           github.actor == 'Alexey-Kamenev'
          ) 
     steps:
       - name: Check if comment is issued by authorized person

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- AMP for derivatives.
+
 ### Changed
 
 ### Deprecated

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 install:
 	pip install --upgrade pip && \
-		pip install -e .
+		pip install -e . --no-build-isolation
 
 setup-ci:
 	pip install pre-commit && \
@@ -17,7 +17,7 @@ lint:
 	# pre-commit run markdownlint -a
 	echo "Lint CI stage not currently implemented"
 
-license: 
+license:
 	pre-commit run license -a
 
 doctest:
@@ -27,7 +27,7 @@ doctest:
 	# 	--doctest-modules modulus/ --ignore-glob=*internal*
 	echo "Doctest CI stage not currently implemented"
 
-pytest: 
+pytest:
 	coverage run \
 		--rcfile='test/coverage.pytest.rc' \
 		-m pytest test/
@@ -60,4 +60,3 @@ container-ci:
 
 container-docs:
 	docker build -t modulus-sym:docs --build-arg TARGETPLATFORM=${TARGETPLATFORM} --target docs -f Dockerfile .
-

--- a/modulus/sym/amp.py
+++ b/modulus/sym/amp.py
@@ -1,0 +1,634 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+import logging
+from collections import defaultdict
+from torch.autograd import Function
+from torch.amp.grad_scaler import _refresh_per_optimizer_state
+from typing import List, Dict, Any
+from enum import Enum
+from termcolor import colored
+from . import modulus_ext
+
+Tensor = torch.Tensor
+logger = logging.getLogger(__name__)
+
+
+class AmpMode(Enum):
+    PER_ORDER_SCALER = 0
+    PER_TERM_SCALER = 1
+
+
+class AmpManager(object):
+    _shared_state = {}
+
+    def __new__(cls):
+        obj = super(AmpManager, cls).__new__(cls)
+        obj.__dict__ = cls._shared_state
+
+        # Set the defaults
+        if not hasattr(obj, "_enabled"):
+            obj._enabled = False
+        if not hasattr(obj, "_mode"):
+            obj._mode = AmpMode.PER_ORDER_SCALER
+        if not hasattr(obj, "_dtype"):
+            obj._dtype = torch.float16
+        if not hasattr(obj, "_default_max_scale"):
+            obj._default_max_scale = 2**0
+        if not hasattr(obj, "_autocast_activation"):
+            obj._autocast_activation = False
+        if not hasattr(obj, "_autocast_firstlayer"):
+            obj._autocast_firstlayer = False
+
+        if not hasattr(obj, "_special_terms"):
+            obj._special_terms = []
+        if not hasattr(obj, "_custom_max_scales"):
+            obj._custom_max_scales = {}
+
+        return obj
+
+    @property
+    def enabled(self):
+        return self._enabled
+
+    @enabled.setter
+    def enabled(self, flag):
+        self._enabled = flag
+
+    @property
+    def mode(self):
+        return self._mode
+
+    @mode.setter
+    def mode(self, mode):
+        if mode == "per_order_scaler":
+            self._mode = AmpMode.PER_ORDER_SCALER
+        elif mode == "per_term_scaler":
+            self._mode = AmpMode.PER_TERM_SCALER
+        else:
+            raise ValueError(
+                f"amp mode should be per_order_scaler/per_term_scaler, but found {mode}"
+            )
+
+    @property
+    def dtype(self):
+        return self._dtype
+
+    @dtype.setter
+    def dtype(self, dtype):
+        if dtype == "float16":
+            self._dtype = torch.float16
+        elif dtype == "bfloat16":
+            self._dtype = torch.bfloat16
+        else:
+            raise ValueError(f"amp dtype should be float16/bfloat16, but found {dtype}")
+
+    @property
+    def default_max_scale(self):
+        return self._default_max_scale
+
+    @default_max_scale.setter
+    def default_max_scale(self, scale):
+        self._default_max_scale = scale
+
+    @property
+    def autocast_activation(self):
+        return self._autocast_activation
+
+    @autocast_activation.setter
+    def autocast_activation(self, flag):
+        self._autocast_activation = flag
+
+    @property
+    def autocast_firstlayer(self):
+        return self._autocast_firstlayer
+
+    @autocast_firstlayer.setter
+    def autocast_firstlayer(self, flag):
+        self._autocast_firstlayer = flag
+
+    @property
+    def special_terms(self):
+        return self._special_terms
+
+    @staticmethod
+    def register_special_term(term, max_scale=None):
+        assert isinstance(term, str), "term should be a str."
+        manager = AmpManager()
+        if term not in manager._special_terms:
+            manager._special_terms.append(term)
+
+            # set max_scale and message
+            message = f"AMP: registering '{term}' as a special term and will use a separate derivative scaler"
+            if max_scale is not None:
+                # will not overwrite max_scale if it has been specified in the custom_max_scales
+                if term not in manager.custom_max_scales:
+                    manager.custom_max_scales[term] = max_scale
+                message += f", max_scale: {manager.custom_max_scales[term]}"
+            logger.info(message)
+
+    @property
+    def custom_max_scales(self):
+        return self._custom_max_scales
+
+    @custom_max_scales.setter
+    def custom_max_scales(self, scales):
+        self._custom_max_scales = scales
+
+    @property
+    def scaler_enabled(self):
+        return self._enabled and self._dtype == torch.float16
+
+    def __repr__(self):
+        return f"AmpManager: {self._shared_state}"
+
+    def init(
+        self,
+        enabled: bool,
+        mode: "str",
+        dtype: "str",
+        autocast_activation: bool,
+        autocast_firstlayer: bool,
+        default_max_scale_log2: int,
+        custom_max_scales_log2: Dict[Any, int],
+    ):
+        self.enabled = enabled
+        self.mode = mode
+        self.dtype = dtype
+        self.autocast_activation = autocast_activation
+        self.autocast_firstlayer = autocast_firstlayer
+        self.default_max_scale = 2**default_max_scale_log2
+        self.custom_max_scales = {
+            key: 2**s for key, s in custom_max_scales_log2.items()
+        }
+
+
+# Helper functions to make AmpManager singleton work with torchscript
+@torch.jit.ignore
+def amp_manager_scaler_enabled_and_disable_autocast_firstlayer() -> bool:
+    return AmpManager().scaler_enabled and not AmpManager().autocast_firstlayer
+
+
+@torch.jit.ignore
+def amp_manager_scaler_enabled_and_disable_autocast_activation() -> bool:
+    return AmpManager().scaler_enabled and not AmpManager().autocast_activation
+
+
+def foreach_non_finite_check_and_unscale(found_inf, inv_scale, scaled_grads):
+    grad_cat = torch.cat([g.flatten() for g in scaled_grads])
+    # inplace update the found_inf tensor
+    torch.logical_not(torch.all(torch.isfinite(grad_cat)).flatten(), out=found_inf)
+    return [g * inv_scale for g in scaled_grads]
+
+
+class GradScaler(torch.cuda.amp.GradScaler):
+    def __init__(
+        self,
+        *args,
+        max_scale=2.0**30,
+        recover_threshold=2.0**6,
+        recover_growth_interval=100,
+        **kwargs,
+    ):
+        """
+        Modified GradScaler that supports max_scale and "recover mode".
+
+        Parameters
+        ---
+        max_scale : float
+            This is the upper bound of the current scaling factor.
+        recover_threshold : float
+            Allowing quickly recover the scaling factor when it is below or equal
+            than this threshold. It is useful for FourierNetArch.
+        recover_growth_interval : int
+            The growth_interval that will be used when the scaling factor is less
+            or equal than the recover_threshold.
+        """
+        super().__init__(*args, **kwargs)
+        if self._enabled:
+            self._max_scale = max_scale
+            self._recover_threshold = recover_threshold
+            self._recover_growth_interval = recover_growth_interval
+            assert (
+                self._init_scale <= self._max_scale
+            ), "init_scale should not be greater than max_scale"
+            assert (
+                self._recover_threshold <= self._max_scale
+            ), "recover_threshold should not be greater than max_scale"
+            assert (
+                self._recover_growth_interval <= self._growth_interval
+            ), "recover_growth_interval should not be greater than growth_interval"
+
+    def update(self, new_scale=None):
+        """
+        Updates the scaling factor.
+        Copy and paste from:
+        https://github.com/pytorch/pytorch/blob/dadfe1c7bf0beee0aa64edc485059e511f56a4ca/torch/cuda/amp/grad_scaler.py#L344
+
+        The only Modification here is the custom `_amp_update_scale_` kernel, this allows
+            1. A upper bound (`max_scale`) for the scaling factor.
+            2. Updating the scaling factor more frequently if it is less or equal than
+                the recover_threshold.
+        """
+        if not self._enabled:
+            return
+
+        _scale, _growth_tracker = self._check_scale_growth_tracker("update")
+
+        if new_scale is not None:
+            # Accept a new user-defined scale.
+            if isinstance(new_scale, float):
+                self._scale.fill_(new_scale)  # type: ignore[union-attr]
+            else:
+                reason = "new_scale should be a float or a 1-element torch.cuda.FloatTensor with requires_grad=False."
+                assert isinstance(new_scale, torch.cuda.FloatTensor), reason  # type: ignore[attr-defined]
+                assert new_scale.numel() == 1, reason
+                assert new_scale.requires_grad is False, reason
+                self._scale.copy_(new_scale)  # type: ignore[union-attr]
+        else:
+            # Consume shared inf/nan data collected from optimizers to update the scale.
+            # If all found_inf tensors are on the same device as self._scale, this operation is asynchronous.
+            found_infs = [
+                found_inf.to(device=_scale.device, non_blocking=True)
+                for state in self._per_optimizer_states.values()
+                for found_inf in state["found_inf_per_device"].values()
+            ]
+
+            assert len(found_infs) > 0, "No inf checks were recorded prior to update."
+
+            found_inf_combined = found_infs[0]
+            if len(found_infs) > 1:
+                for i in range(1, len(found_infs)):
+                    found_inf_combined += found_infs[i]
+
+            if found_inf_combined.bool().item():
+                logger.info(
+                    colored(
+                        f"grad_scaler found infs, {self.state_dict()}",
+                        "yellow",
+                    )
+                )
+
+            torch.ops.modulus_ext._amp_update_scale_(
+                _scale,
+                _growth_tracker,
+                found_inf_combined,
+                self._growth_factor,
+                self._backoff_factor,
+                self._growth_interval,
+                self._max_scale,
+                self._recover_threshold,
+                self._recover_growth_interval,
+            )
+
+        # To prepare for next iteration, clear the data collected from optimizers this iteration.
+        self._per_optimizer_states = defaultdict(_refresh_per_optimizer_state)
+
+    def state_dict(self):
+        if not self._enabled:
+            return {}
+
+        state = super().state_dict()
+        state.update(
+            {
+                "max_scale": self._max_scale,
+                "recover_threshold": self._recover_threshold,
+                "recover_growth_interval": self._recover_growth_interval,
+            }
+        )
+        return state
+
+    def load_state_dict(self, state_dict):
+        if not self._enabled:
+            return
+
+        super().load_state_dict(state_dict)
+        self._max_scale = state_dict["max_scale"]
+        self._recover_threshold = state_dict["recover_threshold"]
+        self._recover_growth_interval = state_dict["recover_growth_interval"]
+
+    def __getstate__(self):
+        state = super().__getstate__()
+        if self._enabled:
+            state["_max_scale"] = self._max_scale
+            state["_recover_threshold"] = self._recover_threshold
+            state["_recover_growth_interval"] = self._recover_growth_interval
+
+    def get_max_scale(self):
+        r"""
+        Returns a Python float containing the current max_scale.
+        """
+        return self._max_scale
+
+
+class DerivScaler(GradScaler):
+    def __init__(
+        self,
+        *args,
+        init_scale=2.0**0,
+        max_scale=2.0**0,
+        recover_threshold=2.0**-6,
+        recover_growth_interval=100,
+        **kwargs,
+    ):
+        """
+        DerivScaler based on the GradScaler.
+
+        The main difference between DerivScaler and GradScaler is that GradScaler unscales
+        the optimizer's weight gradients, while DerivScaler unscales the derivative tensors.
+
+        Parameters
+        ---
+        max_scale : float
+            This is the upper bound of the current scaling factor.
+        recover_threshold : float
+            Allowing quickly recover the scaling factor when it is below or equal
+            than this threshold. It is useful for FourierNetArch.
+        recover_growth_interval : int
+            The growth_interval that will be used when the scaling factor is less
+            or equal than the recover_threshold.
+        """
+        super().__init__(
+            *args,
+            init_scale=init_scale,
+            max_scale=max_scale,
+            recover_threshold=recover_threshold,
+            recover_growth_interval=recover_growth_interval,
+            **kwargs,
+        )
+
+        if self._enabled:
+            self._found_inf = None
+
+    def _lazy_init_found_inf(self):
+        self._found_inf = torch.full(
+            (1,), 0.0, dtype=torch.float32, device=self._scale.device
+        )
+
+    def _reset_found_inf(self):
+        self._found_inf.zero_()
+
+    def _check_found_inf(self, funcname):
+        fix = "This may indicate your script did not use scaler.scale(loss or outputs) earlier in the iteration."
+        assert self._found_inf is not None, (
+            "Attempted {} but _found_inf is None.  ".format(funcname) + fix
+        )
+        return self._found_inf
+
+    def _unscale_grads_(self):
+        raise RuntimeError("Function should not be called")
+
+    def unscale_(self):
+        raise RuntimeError("Function should not be called")
+
+    def step(self):
+        raise RuntimeError("Function should not be called")
+
+    def scale(self, *args, **kwargs):
+        out = super().scale(*args, **kwargs)
+        if not self._enabled:
+            return out
+        if self._found_inf is None:
+            self._lazy_init_found_inf()
+        return out
+
+    def unscale_deriv(self, grad: List[Tensor]):
+        """
+        Return unscaled derivatives which are also checked for infs/NaNs.
+
+        Parameters
+        ----------
+        grad : List[Tensor]
+            A list of derivative tensors need to be unscaled.
+
+        Returns
+        -------
+        List[Tensor]
+            Unscaled derivatives
+        """
+        if not self._enabled:
+            return grad
+
+        self._check_scale_growth_tracker("unscale_deriv")
+        self._check_found_inf("unscale_deriv")
+
+        inv_scale = self._scale.reciprocal()
+        found_inf = torch.full((1,), 0.0, dtype=torch.float32, device=inv_scale.device)
+        grad = foreach_non_finite_check_and_unscale(found_inf, inv_scale, grad)
+
+        self._found_inf += found_inf
+        return grad
+
+    @property
+    def found_inf(self):
+        """
+        Returns a Python bool containing the current found_inf state.
+        If the scaler is disabled or there are no derivative nodes in the model, return False.
+
+        .. warning::
+            :meth:`found_inf` incurs a CPU-GPU sync.
+
+        .. warning::
+            :meth:`found_inf` should be called before function `update`, since `update` will reset the
+            _found_inf state.
+        """
+        if not self._enabled:
+            return False
+
+        if self._found_inf == None:
+            logger.warning(
+                "deriv_scaler.scale() never got called, "
+                "please make sure there are no derivative nodes in the model."
+            )
+            return False
+
+        _found_inf = self._check_found_inf("found_inf")
+        return _found_inf.bool().item()
+
+    def _get_found_inf_tensor(self):
+        """
+        Return the tensor of _found_inf, should only be called when scaler is enabled.
+        """
+        _found_inf = self._check_found_inf("_get_found_inf_tensor")
+        return _found_inf
+
+    def update(self):
+        """
+        Updates the scale factor.
+
+        If self._found_inf > 0, the scale is multiplied by ``backoff_factor`` to reduce it.
+        If ``growth_interval`` unskipped iterations occurred consecutively, the scale is
+        multiplied by ``growth_factor`` to increase it.
+        If the scaling factor is less or equal to the recover_threshold, it will grow more
+        frequently (using the recover_growth_interval) to avoid decreasing too small and
+        stopping the training process.
+        The max_scale defins a upper bound for the scaling factor.
+
+        .. warning::
+            :meth:`update` should only be called at the end of the iteration.
+        """
+        if not self._enabled:
+            return
+
+        _scale, _growth_tracker = self._check_scale_growth_tracker("update")
+        _found_inf = self._check_found_inf("update")
+
+        torch.ops.modulus_ext._amp_update_scale_(
+            _scale,
+            _growth_tracker,
+            _found_inf,
+            self._growth_factor,
+            self._backoff_factor,
+            self._growth_interval,
+            self._max_scale,
+            self._recover_threshold,
+            self._recover_growth_interval,
+        )
+
+        # To prepare for next iteration, reset found_inf states
+        self._reset_found_inf()
+
+
+class DerivScalers(object):
+    def __init__(
+        self,
+        init_scale=2.0**0,
+        max_scale=2.0**0,
+        growth_factor=2.0,
+        backoff_factor=0.5,
+        growth_interval=2000,
+        enabled=True,
+        recover_threshold=2.0**-6,
+        recover_growth_interval=100,
+    ):
+        """
+        A container that holds all the derivative scalers.
+        """
+
+        self._enabled = enabled
+        self._growth_factor = growth_factor
+        self._backoff_factor = backoff_factor
+        self._growth_interval = growth_interval
+        self._init_scale = init_scale
+        self._max_scale = max_scale
+        self._recover_threshold = recover_threshold
+        self._recover_growth_interval = recover_growth_interval
+
+        self._scalers = {}
+
+    def get_scaler(self, key):
+        """
+        Return / create a deriv_scaler by key.
+        """
+        # create a scaler if the key is not present
+        if key not in self._scalers:
+            # use a custom_max_scale if available
+            if key in AmpManager().custom_max_scales:
+                max_scale = AmpManager().custom_max_scales[key]
+                self._scalers[key] = self._create_scaler(max_scale)
+            else:
+                self._scalers[key] = self._create_scaler()
+        return self._scalers[key]
+
+    def _create_scaler(self, max_scale=None):
+        max_scale = self._max_scale if max_scale is None else max_scale
+        return DerivScaler(
+            init_scale=self._init_scale,
+            growth_factor=self._growth_factor,
+            backoff_factor=self._backoff_factor,
+            growth_interval=self._growth_interval,
+            enabled=self._enabled,
+            max_scale=max_scale,
+            recover_threshold=self._recover_threshold,
+            recover_growth_interval=self._recover_growth_interval,
+        )
+
+    @property
+    def found_inf(self):
+        """
+        Returns True if any derivative scaler found an inf.
+        If this instance is disabled or there are no derivative scalers, return False.
+
+        .. warning::
+            :meth:`found_inf` incurs a CPU-GPU sync.
+
+        .. warning::
+            :meth:`found_inf` should be called before function `update`, since `update` will reset the
+            `_found_inf` state.
+        """
+        if not self._enabled:
+            return False
+
+        if len(self._scalers) == 0:
+            logger.warning(
+                "There are no scalers created in DerivScalers, "
+                "please make sure there are no derivative nodes in the model."
+            )
+            return False
+
+        found_infs = [s._get_found_inf_tensor() for s in self._scalers.values()]
+        found_inf_combined = torch.cat(found_infs).sum()
+        return found_inf_combined.bool().item()
+
+    def update(self):
+        """
+        Updates all the derivative scalers.
+        """
+        if not self._enabled:
+            return
+
+        for s in self._scalers.values():
+            s.update()
+
+    def state_dict(self):
+        """
+        Returns the state dicts of all scalers.
+        If this instance is not enabled, returns an empty dict.
+        """
+        if not self._enabled:
+            return {}
+
+        return {key: scaler.state_dict() for key, scaler in self._scalers.items()}
+
+    def load_state_dict(self, state_dict):
+        """
+        Loads the scalers states.
+        If this instance is disabled, :meth:`load_state_dict` is a no-op.
+        """
+        if not self._enabled:
+            return
+
+        if len(state_dict) == 0:
+            raise RuntimeError(
+                "The source state dict is empty, possibly because it was saved "
+                "from a disabled instance of DerivScalers."
+            )
+
+        for key, state in state_dict.items():
+            scaler = self._scalers[key]
+            scaler.load_state_dict(state)
+
+    def get_scale(self):
+        return {key: scaler.get_scale() for key, scaler in self._scalers.items()}
+
+    def get_max_scale(self):
+        return {key: scaler.get_max_scale() for key, scaler in self._scalers.items()}
+
+    def _get_growth_tracker(self):
+        return {
+            key: scaler._get_growth_tracker() for key, scaler in self._scalers.items()
+        }

--- a/modulus/sym/amp.py
+++ b/modulus/sym/amp.py
@@ -349,7 +349,8 @@ class DerivScaler(GradScaler):
         DerivScaler based on the GradScaler.
 
         The main difference between DerivScaler and GradScaler is that GradScaler unscales
-        the optimizer's weight gradients, while DerivScaler unscales the derivative tensors.
+        the weight gradients (maintained by the optimizer), while DerivScaler unscales the
+        data gradients (higher order derivatives).
 
         Parameters
         ---
@@ -470,13 +471,13 @@ class DerivScaler(GradScaler):
         """
         Updates the scale factor.
 
-        If self._found_inf > 0, the scale is multiplied by ``backoff_factor`` to reduce it.
-        If ``growth_interval`` unskipped iterations occurred consecutively, the scale is
+        If self._found_inf > 0, the scale is multiplied by ``backoff_factor`` to decrease it.
+        If there are ``growth_interval`` consecutive unskipped iterations, the scale is
         multiplied by ``growth_factor`` to increase it.
         If the scaling factor is less or equal to the recover_threshold, it will grow more
         frequently (using the recover_growth_interval) to avoid decreasing too small and
         stopping the training process.
-        The max_scale defins a upper bound for the scaling factor.
+        The max_scale defines an upper bound for the scaling factor.
 
         .. warning::
             :meth:`update` should only be called at the end of the iteration.

--- a/modulus/sym/csrc/AmpKernels.cu
+++ b/modulus/sym/csrc/AmpKernels.cu
@@ -1,9 +1,84 @@
+/*
+From PyTorch:
+
+Copyright (c) 2016-     Facebook, Inc            (Adam Paszke)
+Copyright (c) 2014-     Facebook, Inc            (Soumith Chintala)
+Copyright (c) 2011-2014 Idiap Research Institute (Ronan Collobert)
+Copyright (c) 2012-2014 Deepmind Technologies    (Koray Kavukcuoglu)
+Copyright (c) 2011-2012 NEC Laboratories America (Koray Kavukcuoglu)
+Copyright (c) 2011-2013 NYU                      (Clement Farabet)
+Copyright (c) 2006-2010 NEC Laboratories America (Ronan Collobert, Leon Bottou, Iain Melvin, Jason Weston)
+Copyright (c) 2006      Idiap Research Institute (Samy Bengio)
+Copyright (c) 2001-2004 Idiap Research Institute (Ronan Collobert, Samy Bengio, Johnny Mariethoz)
+
+From Caffe2:
+
+Copyright (c) 2016-present, Facebook Inc. All rights reserved.
+
+All contributions by Facebook:
+Copyright (c) 2016 Facebook Inc.
+
+All contributions by Google:
+Copyright (c) 2015 Google Inc.
+All rights reserved.
+
+All contributions by Yangqing Jia:
+Copyright (c) 2015 Yangqing Jia
+All rights reserved.
+
+All contributions by Kakao Brain:
+Copyright 2019-2020 Kakao Brain
+
+All contributions from Caffe:
+Copyright(c) 2013, 2014, 2015, the respective contributors
+All rights reserved.
+
+All other contributions:
+Copyright(c) 2015, 2016 the respective contributors
+All rights reserved.
+
+Caffe2 uses a copyright model similar to Caffe: each contributor holds
+copyright over their contributions to Caffe2. The project versioning records
+all such contribution and copyright details. If a contributor wants to further
+mark their specific copyright on a particular contribution, they should
+indicate their copyright solely in the commit message of the change when it is
+committed.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+3. Neither the names of Facebook, Deepmind Technologies, NYU, NEC Laboratories America
+   and IDIAP Research Institute nor the names of its contributors may be
+   used to endorse or promote products derived from this software without
+   specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+*/
+// Modified from https://github.com/pytorch/pytorch/blob/release/1.11/aten/src/ATen/native/cuda/AmpKernels.cu#L181
+
 #include <torch/extension.h>
 #include <c10/cuda/CUDAStream.h>
 
 using torch::Tensor;
-
-// Modified from https://github.com/pytorch/pytorch/blob/release/1.11/aten/src/ATen/native/cuda/AmpKernels.cu#L181
 
 // amp_update_scale_cuda_kernel is launched with a single thread to compute the new scale.
 // The scale factor is maintained and updated on the GPU to avoid synchronization.

--- a/modulus/sym/csrc/AmpKernels.cu
+++ b/modulus/sym/csrc/AmpKernels.cu
@@ -1,0 +1,99 @@
+#include <torch/extension.h>
+#include <c10/cuda/CUDAStream.h>
+
+using torch::Tensor;
+
+// Modified from https://github.com/pytorch/pytorch/blob/release/1.11/aten/src/ATen/native/cuda/AmpKernels.cu#L181
+
+// amp_update_scale_cuda_kernel is launched with a single thread to compute the new scale.
+// The scale factor is maintained and updated on the GPU to avoid synchronization.
+__global__ void amp_update_scale_cuda_kernel(float* current_scale,
+                                             int* growth_tracker,
+                                             float* found_inf,
+                                             float growth_factor,
+                                             float backoff_factor,
+                                             int growth_interval,
+                                             float max_scale,
+                                             float recover_threshold,
+                                             int recover_growth_interval) {
+  if (*found_inf) {
+    *current_scale = (*current_scale)*backoff_factor;
+    *growth_tracker = 0;
+  } else {
+    // Entering this branch means we just carried out a successful step,
+    // so growth_tracker is incremented before comparing to growth_interval.
+    auto successful = (*growth_tracker) + 1;
+    // decide whether to use the recover_growth_interval
+    growth_interval = (*current_scale) <= recover_threshold ? recover_growth_interval : growth_interval;
+    if (successful == growth_interval) {
+      // grow the scale then clamp with max_scale
+      *current_scale = min((*current_scale) * growth_factor, max_scale);
+      *growth_tracker = 0;
+    } else {
+      *growth_tracker = successful;
+    }
+  }
+}
+
+// _amp_update_scale_cuda asynchronously updates the scale tensor in place.
+//
+// Args:
+// current_scale:  A one-element cuda float tensor containing the scale value.
+// growth_tracker:  A one-element torch.cuda.IntTensor containing the number of recent consecutive unskipped steps.
+// found_inf:  A one-element cuda float tensor. If > 0, indicates that infs/nans were found by the relevant
+//             prior _amp_non_finite_check_and_unscale_cuda call, and 0 if no infs/nans were found.
+// growth_factor:  Multiplier if no infs/NaNs were found (typically slightly > 1).
+// backoff_factor:  Multiplier if infs/NaNs were found (typically 0.5).
+// growth_interval:  Number of consecutive unskipped steps that must occur for current_scale to be multiplied by
+//                   growth_factor.
+// max_scale:  The maximum value the scale could grow.
+// recover_threshold:  Allowing quickly recover the scaling factor when it is less or equal than this threshold.
+// recover_growth_interval:  The growth_interval that will be used when the scaling factor is less or equal than
+//                           the recover_threshold.
+//
+// Returns:
+// current_scale
+Tensor& _amp_update_scale_cuda_(Tensor& current_scale,
+                                Tensor& growth_tracker,
+                                const Tensor& found_inf,
+                                double growth_factor,
+                                double backoff_factor,
+                                int64_t growth_interval,
+                                double max_scale,
+                                double recover_threshold,
+                                int64_t recover_growth_interval)
+{
+  TORCH_CHECK(growth_tracker.is_cuda(), "growth_tracker must be a CUDA tensor.");
+  TORCH_CHECK(current_scale.is_cuda(), "current_scale must be a CUDA tensor.");
+  TORCH_CHECK(found_inf.is_cuda(), "found_inf must be a CUDA tensor.");
+  TORCH_CHECK(growth_tracker.numel() == 1, "growth_tracker must be a 1-element tensor.");
+  TORCH_CHECK(current_scale.numel() == 1, "current_scale must be a 1-element tensor.");
+  TORCH_CHECK(found_inf.numel() == 1, "found_inf must be a 1-element tensor.");
+  TORCH_CHECK(growth_tracker.scalar_type() == at::ScalarType::Int, "growth_tracker must be an int tensor.");
+  TORCH_CHECK(current_scale.scalar_type() == at::ScalarType::Float, "current_scale must be a float tensor.");
+  TORCH_CHECK(found_inf.scalar_type() == at::ScalarType::Float, "found_inf must be a float tensor.");
+
+  amp_update_scale_cuda_kernel<<<1, 1, 0, at::cuda::getCurrentCUDAStream()>>>(
+    current_scale.data_ptr<float>(),
+    growth_tracker.data_ptr<int>(),
+    found_inf.data_ptr<float>(),
+    growth_factor,
+    backoff_factor,
+    growth_interval,
+    max_scale,
+    recover_threshold,
+    recover_growth_interval);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+  return current_scale;
+}
+
+TORCH_LIBRARY(modulus_ext, m) {
+  m.def("_amp_update_scale_(Tensor(a!) self, Tensor(b!) growth_tracker, Tensor found_inf, float scale_growth_factor, float scale_backoff_factor, int growth_interval, float max_scale, float recover_threshold, int recover_growth_interval) -> Tensor(a!)");
+}
+
+TORCH_LIBRARY_IMPL(modulus_ext, CUDA, m) {
+  m.impl("_amp_update_scale_", _amp_update_scale_cuda_);
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {}

--- a/modulus/sym/domain/domain.py
+++ b/modulus/sym/domain/domain.py
@@ -296,7 +296,7 @@ class Domain:
         """
         Setup derivative scalers.
 
-        Iterate over all constraints and their graphs to setup derivative scalers.
+        Iterate over all constraints and their corresponding graphs to set up derivative scalers.
         Specifically, we are looking for Derivative node and FuncArch node in the
         graph to do this setup.
         We don't use Autocast for inferencers, validators, and monitors, because

--- a/modulus/sym/eq/derivatives.py
+++ b/modulus/sym/eq/derivatives.py
@@ -118,12 +118,11 @@ class Derivative(torch.nn.Module):
 
             # Calculate gradient using Autodiff.
             with torch.cuda.amp.autocast(enabled=False):
-                # Autograd within the autocast region is not recommended and could
-                # have unpredicted behavior. Autocast has thread-local configurations.
-                # Because Autograd runs in a different thread, so it could have
-                # different/default AMP dtype from the one we specified in the forward
-                # thread. Disabling autocast here will allow Autograd to run the same
-                # dtype as the forward pass.
+                # Autocast needs to be disabled because using Autograd within the autocast region
+                # is not recommended and could have unpredictable behavior. Autocast relies on
+                # thread-local configurations, and since Autograd runs in a different thread, it
+                # could use a different/default AMP dtype than the one specified in the forward thread.
+                # Disabling autocast here will allow Autograd to run the same dtype as the forward pass.
                 grad = gradient(var, grad_var)
 
             if self.scaler_enabled:

--- a/modulus/sym/eq/pdes/navier_stokes.py
+++ b/modulus/sym/eq/pdes/navier_stokes.py
@@ -19,6 +19,7 @@
 
 from sympy import Symbol, Function, Number
 
+from modulus.sym.amp import AmpManager
 from modulus.sym.eq.pde import PDE
 from modulus.sym.node import Node
 
@@ -99,6 +100,12 @@ class NavierStokes(PDE):
         # kinematic viscosity
         if isinstance(nu, str):
             nu = Function(nu)(*input_variables)
+            # When AMP scalers are enabled, and we are using zero equation
+            # models with explicit nu expressions, we have to use a separate
+            # derivative scaler for nu because the dynamic range of nu is
+            # much smaller than the other second-order derivatives.
+            if AmpManager().scaler_enabled:
+                AmpManager().register_special_term(nu, max_scale=2**20)
         elif isinstance(nu, (float, int)):
             nu = Number(nu)
 

--- a/modulus/sym/hydra/amp.py
+++ b/modulus/sym/hydra/amp.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Supported Modulus AMP configs
+"""
+
+from dataclasses import dataclass, field
+from hydra.core.config_store import ConfigStore
+from typing import Dict, Any
+from omegaconf import MISSING
+
+
+@dataclass
+class AmpConf:
+    enabled: bool = MISSING
+    mode: str = MISSING
+    dtype: str = MISSING
+    autocast_activation: bool = MISSING
+    autocast_firstlayer: bool = MISSING
+    default_max_scale_log2: int = MISSING
+    # Comment out the following line solves an error for hydra
+    # The Error message: Missing mandatory value: amp.custom_max_scales_log2
+    # custom_max_scales_log2: Dict[Any, int] = MISSING
+
+
+@dataclass
+class DefaultAmpConf(AmpConf):
+    enabled: bool = False
+    mode: str = "per_order_scaler"  # another option is "per_term_scaler"
+    dtype: str = "float16"
+    # TODO set default as True once we have fused SILU support
+    autocast_activation: bool = False
+    autocast_firstlayer: bool = False
+    default_max_scale_log2: int = 0
+    custom_max_scales_log2: Dict[Any, int] = field(default_factory=lambda: {})
+
+
+def register_amp_configs() -> None:
+    cs = ConfigStore.instance()
+    cs.store(
+        group="amp",
+        name="default",
+        node=DefaultAmpConf,
+    )

--- a/modulus/sym/hydra/callbacks.py
+++ b/modulus/sym/hydra/callbacks.py
@@ -28,6 +28,7 @@ from hydra.experimental.callback import Callback
 from typing import Any
 from omegaconf import DictConfig, OmegaConf
 
+from modulus.sym.amp import AmpManager
 from modulus.sym.distributed import DistributedManager
 from modulus.sym.manager import JitManager, JitArchMode, GraphManager
 
@@ -64,8 +65,21 @@ class ModulusCallback(Callback):
             jit_manager.enabled = False
             logger.warning("Disabling JIT because functorch does not work with it.")
 
+        # amp manager
+        amp_manager = AmpManager()
+        amp_manager.init(
+            config.amp.enabled,
+            config.amp.mode,
+            config.amp.dtype,
+            config.amp.autocast_activation,
+            config.amp.autocast_firstlayer,
+            config.amp.default_max_scale_log2,
+            config.amp.custom_max_scales_log2,
+        )
+
         logger.info(jit_manager)
         logger.info(graph_manager)
+        logger.info(amp_manager)
 
 
 DefaultCallbackConfigs = DictConfig(

--- a/modulus/sym/hydra/config.py
+++ b/modulus/sym/hydra/config.py
@@ -47,7 +47,7 @@ class ModulusConfig:
     network_dir: str = "."
     initialization_network_dir: str = ""
     save_filetypes: str = "vtk"
-    summary_histograms: bool = False
+    summary_histograms: str = "off"
     jit: bool = version.parse(torch.__version__) >= version.parse(JIT_PYTORCH_VERSION)
     jit_use_nvfuser: bool = True
     jit_arch_mode: str = "only_activation"
@@ -83,6 +83,7 @@ class ModulusConfig:
 
 default_defaults = [
     {"training": "default_training"},
+    {"amp": "default"},
     {"graph": "default"},
     {"stop_criterion": "default_stop_criterion"},
     {"profiler": "nvtx"},
@@ -103,6 +104,7 @@ class DefaultModulusConfig(ModulusConfig):
 # Modulus config for debugging
 debug_defaults = [
     {"training": "default_training"},
+    {"amp": "default"},
     {"graph": "default"},
     {"stop_criterion": "default_stop_criterion"},
     {"profiler": "nvtx"},
@@ -124,6 +126,7 @@ class DebugModulusConfig(ModulusConfig):
 # Modulus config with experimental features (use caution)
 experimental_defaults = [
     {"training": "default_training"},
+    {"amp": "default"},
     {"graph": "default"},
     {"stop_criterion": "default_stop_criterion"},
     {"profiler": "nvtx"},

--- a/modulus/sym/hydra/training.py
+++ b/modulus/sym/hydra/training.py
@@ -40,8 +40,8 @@ class TrainingConf:
     save_network_freq: int = MISSING
     print_stats_freq: int = MISSING
     summary_freq: int = MISSING
-    amp: bool = MISSING
-    amp_dtype: str = MISSING
+    grad_clip_max_norm: float = MISSING
+    monitor_grad_clip: bool = MISSING
 
 
 @dataclass
@@ -56,8 +56,8 @@ class DefaultTraining(TrainingConf):
     save_network_freq: int = 1000
     print_stats_freq: int = 100
     summary_freq: int = 1000
-    amp: bool = False
-    amp_dtype: str = "float16"
+    grad_clip_max_norm: float = 0.5
+    monitor_grad_clip: bool = True
 
     ntk: NTKConf = NTKConf()
 

--- a/modulus/sym/hydra/utils.py
+++ b/modulus/sym/hydra/utils.py
@@ -22,6 +22,8 @@ import logging
 import copy
 import pprint
 
+import matplotlib.pyplot
+
 from termcolor import colored
 from pathlib import Path
 from omegaconf import DictConfig, OmegaConf, MISSING
@@ -35,6 +37,7 @@ from modulus.sym.models.arch import Arch
 from modulus.sym.distributed import DistributedManager
 from modulus.sym.models.utils import ModulusModels
 
+from .amp import register_amp_configs
 from .arch import ModelConf
 from .config import register_modulus_configs, ModulusConfig
 from .hydra import register_hydra_configs
@@ -51,6 +54,8 @@ from .graph import register_graph_configs
 
 
 logger = logging.getLogger(__name__)
+# disable matplotlib logging in debug mode
+matplotlib.pyplot.set_loglevel("info")
 
 
 def main(config_path: str, config_name: str = "config"):
@@ -74,6 +79,7 @@ def main(config_path: str, config_name: str = "config"):
             register_scheduler_configs()
             register_training_configs()
             register_modulus_configs()
+            register_amp_configs()
             register_graph_configs()
 
             # Set number of intraop torch CPU threads

--- a/modulus/sym/solver/solver.py
+++ b/modulus/sym/solver/solver.py
@@ -23,6 +23,7 @@ from typing import List, Union, Tuple, Callable
 from omegaconf import DictConfig
 import warnings
 
+from modulus.sym.amp import DerivScalers
 from modulus.sym.trainer import Trainer
 from modulus.sym.domain import Domain
 from modulus.sym.loss.aggregator import NTK
@@ -85,6 +86,7 @@ class Solver(Trainer):
             self.aggregator,
             self.scheduler,
             self.scaler,
+            self.deriv_scalers,
             self.log,
             self.manager,
             self.device,
@@ -97,6 +99,7 @@ class Solver(Trainer):
             self.aggregator,
             self.scheduler,
             self.scaler,
+            self.deriv_scalers,
             self.log,
             self.device,
         )
@@ -125,6 +128,7 @@ class Solver(Trainer):
             self.aggregator,
             self.scheduler,
             self.scaler,
+            self.deriv_scalers,
             step,
         )
 
@@ -169,6 +173,9 @@ class Solver(Trainer):
 
     def get_num_losses(self):
         return self.domain.get_num_losses()
+
+    def setup_deriv_scaler(self, deriv_scalers: DerivScalers):
+        self.domain.setup_deriv_scaler(deriv_scalers)
 
     def solve(self, sigterm_handler=None):
         if self.cfg.run_mode == "train":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm"]
+requires = ["setuptools", "setuptools-scm", "torch"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -45,7 +45,7 @@ dynamic = ["version"]
 version = {attr = "modulus.sym.__version__"}
 
 [tool.setuptools.packages.find]
-include = ["modulus.*"] 
+include = ["modulus.*"]
 
 [tool.setuptools.package-data]
 "*" = ["*.yaml"]

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,10 @@ from torch.utils.cpp_extension import CUDAExtension, BuildExtension
 
 def cuda_extension():
     cuda_version = float(torch.version.cuda)
-    nvcc_args = []
+    nvcc_args = [
+        "-gencode=arch=compute_70,code=sm_70",
+        "-gencode=arch=compute_75,code=sm_75",
+    ]
     if cuda_version >= 11:
         nvcc_args.append("-gencode=arch=compute_80,code=sm_80")
     if cuda_version >= 11.1:

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import glob
+from setuptools import setup
+
+import torch
+from torch.utils.cpp_extension import CUDAExtension, BuildExtension
+
+
+def cuda_extension():
+    cuda_version = float(torch.version.cuda)
+    nvcc_args = []
+    if cuda_version >= 11:
+        nvcc_args.append("-gencode=arch=compute_80,code=sm_80")
+    if cuda_version >= 11.1:
+        nvcc_args.append("-gencode=arch=compute_86,code=sm_86")
+    if cuda_version >= 12:
+        nvcc_args.append("-gencode=arch=compute_90,code=sm_90")
+
+    return CUDAExtension(
+        name="modulus.sym.modulus_ext",
+        sources=glob.glob("modulus/sym/csrc/*.cu"),
+        extra_compile_args={"cxx": ["-std=c++14"], "nvcc": nvcc_args},
+    )
+
+
+setup(
+    ext_modules=[cuda_extension()],
+    cmdclass={"build_ext": BuildExtension},
+)

--- a/test/test_amp.py
+++ b/test/test_amp.py
@@ -1,0 +1,302 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+import pytest
+import torch.nn as nn
+
+from modulus.sym.amp import DerivScaler, AmpManager
+from modulus.sym.eq.derivatives import gradient
+from modulus.sym import modulus_ext
+
+
+Tensor = torch.Tensor
+skip_if_no_gpu = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="There is no GPU to run this test"
+)
+# ensure torch.rand() is deterministic
+_ = torch.manual_seed(0)
+
+
+@skip_if_no_gpu
+def test_run_deriv_scaler():
+    assert torch.cuda.is_available()
+    device = "cuda:0"
+    deriv_scaler = DerivScaler(
+        init_scale=2.0**0,
+        max_scale=2.0**1,
+        growth_interval=2,
+        recover_threshold=2.0**-1,
+        recover_growth_interval=1,
+    )
+
+    x = torch.ones((100, 1), device=device)
+    y = torch.ones((100, 1), device=device)
+    # model: x, y -> u
+    model = nn.Sequential(
+        nn.Linear(2, 10),
+        nn.Tanh(),
+        nn.Linear(10, 1),
+    ).to(device)
+
+    def run(x, y):
+        x = x.detach().clone().requires_grad_()
+        y = y.detach().clone().requires_grad_()
+        # forward with amp autocast
+        with torch.cuda.amp.autocast():
+            u = model(torch.cat([x, y], dim=-1))
+            # first order derivatives: u__x and u__y
+            u_scale = deriv_scaler.scale(u)
+            grad = gradient(u_scale, [x, y])
+            u__x, u__y = deriv_scaler.unscale_deriv(grad)
+            # loss
+            loss = u.sum() + u__x.sum() + u__y.sum()
+        # backward
+        loss.backward()
+        if not deriv_scaler.found_inf:
+            # scaler.step(self.optimizer)
+            # scaler.update()
+            pass
+        deriv_scaler.update()
+
+    # init state
+    assert deriv_scaler.get_scale() == 2.0**0
+    assert deriv_scaler._get_growth_tracker() == 0
+
+    # simulates 2 consecutive unskipped iteration
+    run(x, y)
+    assert deriv_scaler.get_scale() == 2.0**0
+    assert deriv_scaler._get_growth_tracker() == 1
+    run(x, y)
+    assert deriv_scaler.get_scale() == 2.0**1
+    assert deriv_scaler._get_growth_tracker() == 0
+
+    # simulates reaching to max_scale
+    run(x, y)
+    assert deriv_scaler.get_scale() == 2.0**1
+    assert deriv_scaler._get_growth_tracker() == 1
+    run(x, y)
+    assert deriv_scaler.get_scale() == 2.0**1
+    assert deriv_scaler._get_growth_tracker() == 0
+
+    # simulates 3 consecutive skipped iteration
+    x[0][0] = torch.nan  # inject an NAN
+    run(x, y)
+    assert deriv_scaler.get_scale() == 2.0**0
+    assert deriv_scaler._get_growth_tracker() == 0
+    run(x, y)
+    assert deriv_scaler.get_scale() == 2.0**-1
+    assert deriv_scaler._get_growth_tracker() == 0
+    run(x, y)
+    assert deriv_scaler.get_scale() == 2.0**-2
+    assert deriv_scaler._get_growth_tracker() == 0
+
+    # simulates reaching to recover threashold
+    # scaler will be update more frequently
+    x[0][0] = 1  # remove the NAN
+    run(x, y)
+    assert deriv_scaler.get_scale() == 2.0**-1
+    assert deriv_scaler._get_growth_tracker() == 0
+    run(x, y)
+    assert deriv_scaler.get_scale() == 2.0**0
+    assert deriv_scaler._get_growth_tracker() == 0
+    # no longer in threshold range
+    run(x, y)
+    assert deriv_scaler.get_scale() == 2.0**0
+    assert deriv_scaler._get_growth_tracker() == 1
+
+
+@skip_if_no_gpu
+def test_cuda_graph_deriv_scaler():
+    assert torch.cuda.is_available()
+    device = "cuda:0"
+    deriv_scaler = DerivScaler(init_scale=2**0)
+    g = torch.cuda.CUDAGraph()
+    s = torch.cuda.Stream()
+
+    static_x = torch.ones((100, 1), device=device)
+    static_y = torch.ones((100, 1), device=device)
+    # model: x, y -> u
+    model = nn.Sequential(
+        nn.Linear(2, 10),
+        nn.Tanh(),
+        nn.Linear(10, 1),
+    ).to(device)
+
+    def run():
+        x = static_x.detach().clone().requires_grad_()
+        y = static_y.detach().clone().requires_grad_()
+        # forward with amp autocast
+        with torch.cuda.amp.autocast():
+            u = model(torch.cat([x, y], dim=-1))
+            # first order derivatives: u__x and u__y
+            u_scale = deriv_scaler.scale(u)
+            grad = gradient(u_scale, [x, y])
+            u__x, u__y = deriv_scaler.unscale_deriv(grad)
+            # loss
+            loss = u.sum() + u__x.sum() + u__y.sum()
+        # backward
+        loss.backward()
+
+    s.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(s):
+        # warmup
+        run()
+        # capture
+        g.capture_begin()
+        run()
+        g.capture_end()
+    torch.cuda.current_stream().wait_stream(s)
+
+    # real data
+    real_x = [torch.rand_like(static_x) for _ in range(10)]
+    real_y = [torch.rand_like(static_y) for _ in range(10)]
+    # inject a nan for step 4
+    real_x[3][0] = torch.nan
+
+    # train
+    for i, (x, y) in enumerate(zip(real_x, real_y)):
+        # Fills the graph's input memory with new data to compute on
+        static_x.copy_(x)
+        static_y.copy_(y)
+        # replay() includes forward, backward
+        g.replay()
+        # deriv_scaler step and update
+        if not deriv_scaler.found_inf:
+            # scaler.step(self.optimizer)
+            # scaler.update()
+            pass
+        # manually injected nan should be detected
+        if i == 3:
+            assert deriv_scaler.found_inf
+        deriv_scaler.update()
+
+
+def test_amp_manager():
+    manager = AmpManager()
+
+    # register a special_term
+    manager.register_special_term("nu", 2**10)
+    assert "nu" in manager.special_terms
+    assert "nu" in manager.custom_max_scales
+    assert manager.custom_max_scales["nu"] == 2**10
+
+    # register one without max_scale
+    manager.register_special_term("m")
+    assert "m" in manager.special_terms
+    assert "m" not in manager.custom_max_scales
+
+    # scaler_enbaled
+    manager.enabled = False
+    assert manager.scaler_enabled == False
+
+    # scaler is not enabled for bfloat16
+    manager.enabled = True
+    manager.dtype = "bfloat16"
+    assert manager.scaler_enabled == False
+
+
+@skip_if_no_gpu
+def test_modulus_ext_amp_update_scale():
+    # modified from https://github.com/pytorch/pytorch/blob/release/1.11/test/test_cuda.py#L2079
+    device = "cuda:0"
+    growth = 2.0
+    backoff = 0.25
+    growth_interval = 2
+    max_scale = 2.0**3
+    recover_threshold = 2.0**1
+    recover_growth_interval = 1
+    scale = torch.full((1,), 4.0, dtype=torch.float, device=device)
+    growth_tracker = torch.full((1,), 0.0, dtype=torch.int32, device=device)
+    found_inf = torch.full((1,), 0.0, dtype=torch.float, device="cuda:0")
+
+    def amp_update_scale():
+        torch.ops.modulus_ext._amp_update_scale_(
+            scale,
+            growth_tracker,
+            found_inf,
+            growth,
+            backoff,
+            growth_interval,
+            max_scale,
+            recover_threshold,
+            recover_growth_interval,
+        )
+
+    # Simulates 2 consecutive unskipped iterations
+    amp_update_scale()
+    assert growth_tracker.item() == 1
+    assert scale.item() == 2.0**2
+    amp_update_scale()
+    assert growth_tracker.item() == 0
+    assert scale.item() == 2.0**3
+
+    # Simulates reaching to max_scale upper bound
+    for i in range(4):
+        amp_update_scale()
+        assert growth_tracker.item() == (i + 1) % 2
+        assert scale.item() == 2.0**3
+
+    # Simulates 2 consecutive skipped iteration
+    found_inf.fill_(1.0)
+    amp_update_scale()
+    assert growth_tracker.item() == 0
+    assert scale.item() == 2.0**1
+    amp_update_scale()
+    assert growth_tracker.item() == 0
+    assert scale.item() == 2.0**-1
+
+    # Simulates reaching to recover_threshold, recover_growth_interval is 1
+    found_inf.fill_(0.0)
+    amp_update_scale()
+    assert growth_tracker.item() == 0
+    assert scale.item() == 2.0**0
+    amp_update_scale()
+    assert growth_tracker.item() == 0
+    assert scale.item() == 2.0**1
+    amp_update_scale()
+    assert growth_tracker.item() == 0
+    assert scale.item() == 2.0**2
+
+    # no longer in threshold range
+    amp_update_scale()
+    assert growth_tracker.item() == 1
+    assert scale.item() == 2.0**2
+
+
+def test_scaler_state_dict():
+    scaler1 = DerivScaler(
+        init_scale=2.0**8,
+        max_scale=2.0**30,
+        recover_threshold=2.0**-10,
+        recover_growth_interval=1,
+    )
+    state = scaler1.state_dict()
+
+    scaler2 = DerivScaler()
+    scaler2.load_state_dict(state)
+    assert scaler2._init_scale == 2.0**8
+    assert scaler2._max_scale == 2.0**30
+    assert scaler2._recover_threshold == 2.0**-10
+    assert scaler2._recover_growth_interval == 1
+
+
+if __name__ == "__main__":
+    test_run_deriv_scaler()
+    test_cuda_graph_deriv_scaler()
+    test_amp_manager()
+    test_modulus_ext_amp_update_scale()
+    test_scaler_state_dict()

--- a/test/test_models/test_fully_connected.py
+++ b/test/test_models/test_fully_connected.py
@@ -14,12 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from modulus.sym.models.fully_connected import FullyConnectedArch
-import torch
-import numpy as np
 from pathlib import Path
-from modulus.sym.key import Key
+
+import numpy as np
 import pytest
+import torch
+
+from modulus.sym.key import Key
+from modulus.sym.models.fully_connected import FullyConnectedArch
+
 from .model_test_utils import validate_func_arch_net
 
 dir_path = Path(__file__).parent


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description

Training Physics Informed Neural Networks with Automatic Mixed Precision (AMP) currently leads to infinity loss for several models. This comes from the higher-order derivatives, which could go beyond the FP16 dynamic range (`5.96e-8` to `65504`). For example, the training of lid driven cavity problem got terminated around 3000 steps because `u__y__y` at the corner passes the FP16 maximum value of `65504`. 

The default AMP [GradScaler](https://pytorch.org/tutorials/recipes/recipes/amp_recipe.html#adding-gradscaler) tracks the model parameter gradients but not the derivatives calculated from `torch.autograd.grad`.

## DerivScaler

The derivatives need to be tracked by another scaler because the derivatives and NN parameter gradients have different dynamic ranges.
The dynamic range of FP16 is from 2^-24 to 2^15 (40 powers of 2).  
The following range is different from problem to problem, just for reference
- Typical weight gradient range: 2^-40 to 2^-10
- Typical first order derivative range: 2^-10 to 2^5
- Typical second order derivative range: 2^0 to 2^20

This PR adds a DerivScaler which
1. scales and unscales the derivatives during forward in the derivative node, so the operations used in FP16 are in the good range
2. check INFs/NaNs when unscaling the derivatives. When INFs/NaNs are detected, this iteration will be skipped, and the scale value will be adjusted.

It supports the following features
- Per derivative order scalers (default)
- Per derivative term scalers
- Control the scaling factors
  - Avoid a very low derivative scaling factor
    - use fused activation or disable autocast for activation to avoid intermediate result overflow.
    - Use FP32 for the first layer that produces the high-order derivatives, this layer always overflows and this does not introduce too much perf drop.
  - Avoid scaling factor decreasing too fast, useful for Fourier Neural Network
    - Entering “recover mode” if the scaling factor is less than a predefined threshold. In this mode, the scaling factor grows more frequently.

For more details, please refer to [this publication](https://ml4physicalsciences.github.io/2022/files/NeurIPS_ML4PS_2022_4.pdf).
## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus-sym/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/modulus-sym/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/modulus-sym/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->