### PR TITLE
Bugfix for InferencerPlotter in 1D

### DIFF
--- a/modulus/sym/utils/io/plotter.py
+++ b/modulus/sym/utils/io/plotter.py
@@ -139,7 +139,7 @@ class InferencerPlotter(_Plotter):
         for k in outvar:
             f = plt.figure(figsize=(5, 4), dpi=100)
             if ndim == 1:
-                plt.plot(invar[dims[0]][:, 0], outvar[:, 0])
+                plt.plot(invar[dims[0]][:, 0], outvar[k][:, 0])
                 plt.xlabel(dims[0])
             elif ndim == 2:
                 plt.imshow(outvar[k].T, origin="lower", extent=extent)


### PR DESCRIPTION
`outvar` is a dict so need to select the appropriate key.

<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description

Currently InferencerPlotter doesn't function for 1D data. It throws an error because the `outvar` dictionary is missing a key lookup and tries to index the data array, which obviously doesn't work. This PR corrects that issue.

## Checklist

- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus-sym/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/modulus-sym/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/modulus-sym/issues) is linked to this pull request.

## Dependencies

No dependencies