### PR TITLE
hydra compose register_amp_configs() fix

### DIFF
--- a/modulus/sym/hydra/utils.py
+++ b/modulus/sym/hydra/utils.py
@@ -170,6 +170,7 @@ def compose(
     register_scheduler_configs()
     register_training_configs()
     register_modulus_configs()
+    register_amp_configs()
     register_graph_configs()
 
     cfg = hydra.compose(


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Close #206 

`register_amp_configs()` was called in main() register_decorator but missing in compose(). When user uses compose() to get config it will fail since it can’t find any registered amp defaults.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus-sym/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/modulus-sym/blob/main/CHANGELOG.md) is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/modulus-sym/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->